### PR TITLE
 ![image](https://github.com/user-attachments/assets/5b

### DIFF
--- a/current.md
+++ b/current.md
@@ -20,6 +20,10 @@ title: Current
 
 
 
+# @NASA’s SpaceX Crew-10 Hatch Close
+<iframe width="560" height="315" src="https://www.youtube.com/embed/Gn6qR__BbYg?si=zC0i-yDlc9o81Epk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+<img alt="image" src="https://github.com/user-attachments/assets/f2b8256c-cddb-484b-8101-427823eda8d8" />
 
 
 @nasa-jpl 

--- a/current.md
+++ b/current.md
@@ -20,8 +20,25 @@ title: Current
 
 
 
-# @NASA’s SpaceX Crew-10 Hatch Close
-<iframe width="560" height="315" src="https://www.youtube.com/embed/Gn6qR__BbYg?si=zC0i-yDlc9o81Epk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+![image](https://github.com/user-attachments/assets/5be21c81-f8bd-4505-b33f-2fe7c7e1350e)
+
+[vf](https://www.reddit.com/r/Roms/comments/izaoj0/anyone_have_the_virtua_fighter_1_rom_that_works/) [v](https://www.reddit.com/r/MAME/comments/ub3r4j/im_trying_to_get_virtua_racing_working_and_i_have/)
+
+NASA’s SpaceX Crew-10 Hatch Close [feed](NASA’s SpaceX Crew-10 Hatch Close)
+@nasa @nasa-jpl @blackgirlscode @whitehouse @dhs-gov @datadesk
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/duhHk_Tnt0I?si=wvYtGIW5xUsTaBiU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+Started streaming 27 minutes ago
+The four members of NASA's SpaceX [Crew-10 mission — NASA astronauts](https://www.nasa.gov/news-release/nasa-shares-its-spacex-crew-10-assignments-for-space-station-mission/) Anne McClain and Nichole Ayers, JAXA (Japan Aerospace Exploration Agency) astronaut Takuya Onishi, and Roscosmos cosmonaut Kirill Peskov — prepare to head to Earth as the hatches are closed on their spacecraft. Undocking is scheduled for Friday, Aug. 8, at 6:05 p.m. ET (2205 UTC).
+ 
+During their nearly five months on the space station, Crew-10 contributed to the more than 200 scientific demonstrations and experiments taking place in orbit. These included physiological and psychological studies, material flammability tests for future spacecraft designs, and testing a backup lunar navigation solution.
+ 
+Learn more about Crew-10's [scientific mission: https://go.nasa.gov/4fpVoi5](**https://go.nasa.gov/4fpVoi5)
+Follow the latest Crew-10 [mission updates: https://www.nasa.gov/blogs/crew-10/](https://www.nasa.gov/blogs/crew-10/)
+ 
+Credit: NASA
 
 <img alt="image" src="https://github.com/user-attachments/assets/f2b8256c-cddb-484b-8101-427823eda8d8" />
 


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/5be21c81-f8bd-4505-b33f-2fe7c7e1350e)

[vf](https://www.reddit.com/r/Roms/comments/izaoj0/anyone_have_the_virtua_fighter_1_rom_that_works/) [v](https://www.reddit.com/r/MAME/comments/ub3r4j/im_trying_to_get_virtua_racing_working_and_i_have/)

NASA’s SpaceX Crew-10 Hatch Close [feed](NASA’s SpaceX Crew-10 Hatch Close)
@nasa @nasa-jpl @blackgirlscode @whitehouse @dhs-gov @datadesk

<iframe width="560" height="315" src="https://www.youtube.com/embed/duhHk_Tnt0I?si=wvYtGIW5xUsTaBiU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>

Started streaming 27 minutes ago
The four members of NASA's SpaceX [Crew-10 mission — NASA astronauts](https://www.nasa.gov/news-release/nasa-shares-its-spacex-crew-10-assignments-for-space-station-mission/) Anne McClain and Nichole Ayers, JAXA (Japan Aerospace Exploration Agency) astronaut Takuya Onishi, and Roscosmos cosmonaut Kirill Peskov — prepare to head to Earth as the hatches are closed on their spacecraft. Undocking is scheduled for Friday, Aug. 8, at 6:05 p.m. ET (2205 UTC).
 
During their nearly five months on the space station, Crew-10 contributed to the more than 200 scientific demonstrations and experiments taking place in orbit. These included physiological and psychological studies, material flammability tests for future spacecraft designs, and testing a backup lunar navigation solution.
 
Learn more about Crew-10's [scientific mission: https://go.nasa.gov/4fpVoi5](**https://go.nasa.gov/4fpVoi5)
Follow the latest Crew-10 [mission updates: https://www.nasa.gov/blogs/crew-10/](https://www.nasa.gov/blogs/crew-10/)
 
Credit: @NASA